### PR TITLE
Added HomeKit switches for each radio preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,35 @@
 # Homebridge-Yamaha
+
 homebridge-plugin for Yamaha AVR control with Apple-Homekit.
 
 # Installation
+
 Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for the homebridge server installation. The plugin is published through [NPM](https://www.npmjs.com/package/homebridge-yamaha) and should be installed "globally" by typing:
 
-    sudo npm install -g homebridge-yamaha
+```
+sudo npm install -g homebridge-yamaha
+```
 
-#Configuration
+# Configuration
 
 config.json
 
-"manual_addresses" only needed if Bonjour/Autodetection doesn't work.
+- play_volume - Sets volume to this when turning on, defaults to -48
+- min_volume -
+- max_volume -
+- setMainInputTo - Sets input to this when turning on, no default.
+- show_input_name - Creates a button to display which input is selected, defaults to no
+- manual_addresses - Only required if Bonjour/Autodetection doesn't work.
+- expected_devices - Maximum number of accessories created, defaults to 100
+- discovery_timeout - How long to stay in discovery mode, defaults to 30
+- radio_presets - Create a switch for each radio preset, defaults to false ( true/false )
+- preset_name - Names the switch the frequency of the preset, defaults to true ( true/false ). Otherwise the name is the preset number.
+- zone - Zone name
 
 Example:
 
-  ```json
-  {
+```json
+{
     "bridge": {
         "name": "Homebridge",
         "username": "CC:22:3D:E3:CE:51",
@@ -40,3 +54,4 @@ Example:
         {}
     ]
     }
+```

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function YamahaAVRPlatform(log, config) {
     this.expectedDevices = config["expected_devices"] || 100;
     this.discoveryTimeout = config["discovery_timeout"] || 30;
     this.radioPresets = config["radio_presets"] || false;
-    this.presetName = config["preset_name"] || true;
+    this.presetNum = config["preset_num"] || false;
     this.manualAddresses = config["manual_addresses"] || {};
     this.browser = mdns.createBrowser(mdns.tcp('http'), {
         resolverSequence: sequence
@@ -149,8 +149,8 @@ YamahaAVRPlatform.prototype = {
                     if (this.radioPresets) {
                         yamaha.getTunerPresetList().then(function(presets) {
                             for (var preset in presets) {
-                                this.log("Adding preset %s - %s", preset, presets[preset].value);
-                                if (this.presetName) {
+                                this.log("Adding preset %s - %s", preset, presets[preset].value,this.presetNum);
+                                if ( !this.presetNum ) {
                                     // preset by frequency
                                     var accessory = new YamahaSwitch(this.log, this.config, presets[preset].value, yamaha, sysConfig, preset);
                                 } else {

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ function YamahaSwitch(log, config, name, yamaha, sysConfig, preset) {
 
     this.nameSuffix = config["name_suffix"] || " Speakers";
     this.zone = config["zone"] || 1;
-    this.name = 'Preset ' + name.toString();
+    this.name = 'Preset ' + parseInt(name).toString();
     this.serviceName = name + this.nameSuffix;
     this.setMainInputTo = config["setMainInputTo"];
     this.playVolume = this.config["play_volume"];

--- a/index.js
+++ b/index.js
@@ -25,21 +25,23 @@ var mdns = require('mdns');
 //workaround for raspberry pi
 var sequence = [
     mdns.rst.DNSServiceResolve(),
-    'DNSServiceGetAddrInfo' in mdns.dns_sd ? mdns.rst.DNSServiceGetAddrInfo() : mdns.rst.getaddrinfo({families:[4]}),
+    'DNSServiceGetAddrInfo' in mdns.dns_sd ? mdns.rst.DNSServiceGetAddrInfo() : mdns.rst.getaddrinfo({
+        families: [4]
+    }),
     mdns.rst.makeAddressesUnique()
 ];
 
 module.exports = function(homebridge) {
-  Service = homebridge.hap.Service;
-  Characteristic = homebridge.hap.Characteristic;
-  types = homebridge.hapLegacyTypes;
+    Service = homebridge.hap.Service;
+    Characteristic = homebridge.hap.Characteristic;
+    types = homebridge.hapLegacyTypes;
 
-  fixInheritance(YamahaAVRPlatform.Input, Characteristic);
-  fixInheritance(YamahaAVRPlatform.InputName, Characteristic);
-  fixInheritance(YamahaAVRPlatform.InputService, Service);
+    fixInheritance(YamahaAVRPlatform.Input, Characteristic);
+    fixInheritance(YamahaAVRPlatform.InputName, Characteristic);
+    fixInheritance(YamahaAVRPlatform.InputService, Service);
 
-  homebridge.registerAccessory("homebridge-yamaha", "YamahaAVR", YamahaAVRAccessory);
-  homebridge.registerPlatform("homebridge-yamaha", "YamahaAVR", YamahaAVRPlatform);
+    //  homebridge.registerAccessory("homebridge-yamaha", "YamahaAVR", YamahaAVRAccessory);
+    homebridge.registerPlatform("homebridge-yamaha", "YamahaAVR", YamahaAVRPlatform);
 }
 
 // Necessary because Accessory is defined after we have defined all of our classes
@@ -54,7 +56,7 @@ function fixInheritance(subclass, superclass) {
 
 
 
-function YamahaAVRPlatform(log, config){
+function YamahaAVRPlatform(log, config) {
     this.log = log;
     this.config = config;
     this.zone = config["zone"] || "Main";
@@ -67,39 +69,41 @@ function YamahaAVRPlatform(log, config){
     this.expectedDevices = config["expected_devices"] || 100;
     this.discoveryTimeout = config["discovery_timeout"] || 30;
     this.manualAddresses = config["manual_addresses"] || {};
-    this.browser = mdns.createBrowser(mdns.tcp('http'), {resolverSequence: sequence});
+    this.browser = mdns.createBrowser(mdns.tcp('http'), {
+        resolverSequence: sequence
+    });
 }
 
 // Custom Characteristics and service...
 
 YamahaAVRPlatform.Input = function() {
-  Characteristic.call(this, 'Input', '00001003-0000-1000-8000-135D67EC4377');
-  this.setProps({
-    format: Characteristic.Formats.STRING,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-  });
-  this.value = this.getDefaultValue();
+    Characteristic.call(this, 'Input', '00001003-0000-1000-8000-135D67EC4377');
+    this.setProps({
+        format: Characteristic.Formats.STRING,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+    });
+    this.value = this.getDefaultValue();
 };
 
 
 YamahaAVRPlatform.InputName = function() {
-  Characteristic.call(this, 'Input Name', '00001004-0000-1000-8000-135D67EC4377');
-  this.setProps({
-    format: Characteristic.Formats.STRING,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-  });
-  this.value = this.getDefaultValue();
+    Characteristic.call(this, 'Input Name', '00001004-0000-1000-8000-135D67EC4377');
+    this.setProps({
+        format: Characteristic.Formats.STRING,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+    });
+    this.value = this.getDefaultValue();
 };
 
 
 YamahaAVRPlatform.InputService = function(displayName, subtype) {
-  Service.call(this, displayName, '00000002-0000-1000-8000-135D67EC4377', subtype);
+    Service.call(this, displayName, '00000002-0000-1000-8000-135D67EC4377', subtype);
 
-  // Required Characteristics
-  this.addCharacteristic(YamahaAVRPlatform.Input);
+    // Required Characteristics
+    this.addCharacteristic(YamahaAVRPlatform.Input);
 
-  // Optional Characteristics
-  this.addOptionalCharacteristic(YamahaAVRPlatform.InputName);
+    // Optional Characteristics
+    this.addOptionalCharacteristic(YamahaAVRPlatform.InputName);
 };
 
 
@@ -112,22 +116,24 @@ YamahaAVRPlatform.prototype = {
         browser.stop();
         browser.removeAllListeners('serviceUp'); // cleanup listeners
         var accessories = [];
-        var timer, timeElapsed = 0, checkCyclePeriod = 5000;
+        var timer, timeElapsed = 0,
+            checkCyclePeriod = 5000;
 
         // Hmm... seems we need to prevent double-listing via manual and Bonjour...
         var sysIds = {};
 
-        var setupFromService = function(service){
+        var setupFromService = function(service) {
             var name = service.name;
             //console.log('Found HTTP service "' + name + '"');
             // We can't tell just from mdns if this is an AVR...
             if (service.port != 80) return; // yamaha-nodejs assumes this, so finding one on another port wouldn't do any good anyway.
             var yamaha = new Yamaha(service.host);
             yamaha.getSystemConfig().then(
-                function(sysConfig){
+                function(sysConfig) {
+                    debug(JSON.stringify(sysConfig, null, 2));
                     var sysModel = sysConfig.YAMAHA_AV.System[0].Config[0].Model_Name[0];
                     var sysId = sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0];
-                    if(sysIds[sysId]){
+                    if (sysIds[sysId]) {
                         this.log("WARN: Got multiple systems with ID " + sysId + "! Omitting duplicate!");
                         return;
                     }
@@ -135,19 +141,29 @@ YamahaAVRPlatform.prototype = {
                     this.log("Found Yamaha " + sysModel + " - " + sysId + ", \"" + name + "\"");
                     var accessory = new YamahaAVRAccessory(this.log, this.config, name, yamaha, sysConfig);
                     accessories.push(accessory);
-                    if(accessories.length >= this.expectedDevices)
+
+                    // Add buttons for each preset
+
+                    yamaha.getTunerPresetList().then(function(presets) {
+                        for (var preset in presets) {
+                            this.log("Adding preset", presets[preset].value);
+                            var accessory = new YamahaSwitch(this.log, this.config, presets[preset].value, yamaha, sysConfig, preset);
+                            accessories.push(accessory);
+                        };
+                    }.bind(this));
+
+                    if (accessories.length >= this.expectedDevices)
                         timeoutFunction(); // We're done, call the timeout function now.
-                }.bind(this)
-                ,
-                function(error){
+                }.bind(this),
+                function(error) {
                     debug("DEBUG: Failed getSystemConfig from " + name + ", probably just not a Yamaha AVR.", error);
                 }.bind(this)
             );
         }.bind(this);
 
         // process manually specified devices...
-        for(var key in this.manualAddresses){
-            if(!this.manualAddresses.hasOwnProperty(key)) continue;
+        for (var key in this.manualAddresses) {
+            if (!this.manualAddresses.hasOwnProperty(key)) continue;
             setupFromService({
                 name: key,
                 host: this.manualAddresses[key],
@@ -160,12 +176,12 @@ YamahaAVRPlatform.prototype = {
 
         // The callback can only be called once...so we'll have to find as many as we can
         // in a fixed time and then call them in.
-        var timeoutFunction = function(){
-            if(accessories.length >= that.expectedDevices){
+        var timeoutFunction = function() {
+            if (accessories.length >= that.expectedDevices) {
                 clearTimeout(timer);
             } else {
                 timeElapsed += checkCyclePeriod;
-                if(timeElapsed > that.discoveryTimeout * 1000){
+                if (timeElapsed > that.discoveryTimeout * 1000) {
                     that.log("Waited " + that.discoveryTimeout + " seconds, stopping discovery.");
                 } else {
                     timer = setTimeout(timeoutFunction, checkCyclePeriod);
@@ -180,6 +196,83 @@ YamahaAVRPlatform.prototype = {
         timer = setTimeout(timeoutFunction, checkCyclePeriod);
     }
 };
+
+function YamahaSwitch(log, config, name, yamaha, sysConfig, preset) {
+    this.log = log;
+    this.config = config;
+    this.yamaha = yamaha;
+    this.sysConfig = sysConfig;
+
+    this.nameSuffix = config["name_suffix"] || " Speakers";
+    this.zone = config["zone"] || 1;
+    this.name = 'Radio ' + name.toString();
+    this.serviceName = name + this.nameSuffix;
+    this.setMainInputTo = config["setMainInputTo"];
+    this.playVolume = this.config["play_volume"];
+    this.minVolume = config["min_volume"] || -50.0;
+    this.maxVolume = config["max_volume"] || -20.0;
+    this.gapVolume = this.maxVolume - this.minVolume;
+    this.showInputName = config["show_input_name"] || "no";
+    this.preset = preset;
+}
+
+YamahaSwitch.prototype = {
+
+    getServices: function() {
+        var that = this;
+        var informationService = new Service.AccessoryInformation();
+        var yamaha = this.yamaha;
+
+        informationService
+            .setCharacteristic(Characteristic.Name, this.name)
+            .setCharacteristic(Characteristic.Manufacturer, "Yamaha")
+            .setCharacteristic(Characteristic.Model, this.sysConfig.YAMAHA_AV.System[0].Config[0].Model_Name[0])
+            .setCharacteristic(Characteristic.SerialNumber, this.sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0]);
+
+        var switchService = new Service.Switch(this.name);
+        switchService.getCharacteristic(Characteristic.On)
+            .on('get', function(callback, context) {
+                yamaha.getBasicInfo().then(function(basicInfo) {
+                    this.log('Is On', basicInfo.isOn()); // True
+                    this.log('Input', basicInfo.getCurrentInput()); // Tuner
+
+                    if (basicInfo.isOn() && basicInfo.getCurrentInput() == 'TUNER') {
+
+                        yamaha.getTunerInfo().then(function(result) {
+                            //console.log( 'TunerInfo', JSON.stringify(result,null, 0));
+                            this.log(result.Play_Info[0].Feature_Availability[0]); // Ready
+                            this.log(result.Play_Info[0].Search_Mode[0]); // Preset
+                            this.log(result.Play_Info[0].Preset[0].Preset_Sel[0]); // #
+                            if (result.Play_Info[0].Feature_Availability[0] == 'Ready' &&
+                                result.Play_Info[0].Search_Mode[0] == 'Preset' &&
+                                result.Play_Info[0].Preset[0].Preset_Sel[0] == this.preset) {
+                                callback(false, true);
+                            } else {
+                                callback(false, false);
+                            }
+                        }.bind(this));
+
+                    } else {
+                        // Off
+                        callback(false, false);
+                    }
+
+                }.bind(this), function(error) {
+                    callback(error);
+                });
+
+            }.bind(this))
+            .on('set', function(powerOn, callback) {
+                yamaha.selectTunerPreset(this.preset).then(function() {
+                    debug('Tuning radio to preset %s - %s', this.preset, this.name);
+                    callback(null,1);
+                }.bind(this));
+            }.bind(this));
+
+        return [informationService, switchService];
+    }
+};
+
 
 function YamahaAVRAccessory(log, config, name, yamaha, sysConfig) {
     this.log = log;
@@ -207,20 +300,19 @@ YamahaAVRAccessory.prototype = {
 
         if (playing) {
 
-            return yamaha.powerOn().then(function(){
-                if (that.playVolume) return yamaha.setVolumeTo(that.playVolume*10, that.zone);
+            return yamaha.powerOn().then(function() {
+                if (that.playVolume) return yamaha.setVolumeTo(that.playVolume * 10, that.zone);
                 else return Q();
-            }).then(function(){
+            }).then(function() {
                 if (that.setMainInputTo) return yamaha.setMainInputTo(that.setMainInputTo);
                 else return Q();
-            }).then(function(){
+            }).then(function() {
                 if (that.setMainInputTo == "AirPlay") return yamaha.SendXMLToReceiver(
                     '<YAMAHA_AV cmd="PUT"><AirPlay><Play_Control><Playback>Play</Playback></Play_Control></AirPlay></YAMAHA_AV>'
                 );
                 else return Q();
             });
-        }
-        else {
+        } else {
             return yamaha.powerOff();
         }
     },
@@ -231,85 +323,86 @@ YamahaAVRAccessory.prototype = {
         var yamaha = this.yamaha;
 
         informationService
-                .setCharacteristic(Characteristic.Name, this.name)
-                .setCharacteristic(Characteristic.Manufacturer, "Yamaha")
-                .setCharacteristic(Characteristic.Model, this.sysConfig.YAMAHA_AV.System[0].Config[0].Model_Name[0])
-                .setCharacteristic(Characteristic.SerialNumber, this.sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0]);
+            .setCharacteristic(Characteristic.Name, this.name)
+            .setCharacteristic(Characteristic.Manufacturer, "Yamaha")
+            .setCharacteristic(Characteristic.Model, this.sysConfig.YAMAHA_AV.System[0].Config[0].Model_Name[0])
+            .setCharacteristic(Characteristic.SerialNumber, this.sysConfig.YAMAHA_AV.System[0].Config[0].System_ID[0]);
 
         var switchService = new Service.Switch("Yamaha Power");
         switchService.getCharacteristic(Characteristic.On)
-                .on('get', function(callback, context){
-                    yamaha.isOn().then(
-                        function(result){
-                            callback(false, result);
-                        }.bind(this), function(error){
-                            callback(error, false);
-                        }.bind(this)
-                    );
-                }.bind(this))
-                .on('set', function(powerOn, callback){
-                    this.setPlaying(powerOn).then(function(){
-                        callback(false, powerOn);
-                    }, function(error){
-                        callback(error, !powerOn); //TODO: Actually determine and send real new status.
-                    });
-                }.bind(this));
+            .on('get', function(callback, context) {
+                yamaha.isOn().then(
+                    function(result) {
+                        callback(false, result);
+                    }.bind(this),
+                    function(error) {
+                        callback(error, false);
+                    }.bind(this)
+                );
+            }.bind(this))
+            .on('set', function(powerOn, callback) {
+                this.setPlaying(powerOn).then(function() {
+                    callback(false, powerOn);
+                }, function(error) {
+                    callback(error, !powerOn); //TODO: Actually determine and send real new status.
+                });
+            }.bind(this));
 
-		var audioDeviceService = new Service.Speaker("Speaker");
-		audioDeviceService.addCharacteristic(Characteristic.Volume);
-		var volCx = audioDeviceService.getCharacteristic(Characteristic.Volume);
+        var audioDeviceService = new Service.Speaker("Speaker");
+        audioDeviceService.addCharacteristic(Characteristic.Volume);
+        var volCx = audioDeviceService.getCharacteristic(Characteristic.Volume);
 
-                volCx.on('get', function(callback, context){
-                    yamaha.getBasicInfo(that.zone).then(function(basicInfo){
-                        var v = basicInfo.getVolume()/10.0;
-                        var p = 100 * ((v - that.minVolume) / that.gapVolume);
-                        p = p < 0 ? 0 : p > 100 ? 100 : Math.round(p);
-                        debug("Got volume percent of " + p + "%");
-                        callback(false, p);
-                    }, function(error){
-                        callback(error, 0);
-                    });
-                })
-                .on('set', function(p, callback){
-                    var v = ((p / 100) * that.gapVolume) + that.minVolume;
-                    v = Math.round(v*10.0);
-                    debug("Setting volume to " + v);
-                    yamaha.setVolumeTo(v,that.zone).then(function(){
-                        callback(false, p);
-                    }, function(error){
-                        callback(error, volCx.value);
-                    });
-                })
-                .getValue(null, null); // force an asynchronous get
-
-		var mutingCx = audioDeviceService.getCharacteristic(Characteristic.Mute);
-    
-          mutingCx.on('get', function(callback, context) {
-              yamaha.getBasicInfo(that.zone).then(function(basicInfo){
-                callback(false, basicInfo.isMuted());
-              }, function(error){
-                callback(error, 0);
-              });
+        volCx.on('get', function(callback, context) {
+                yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
+                    var v = basicInfo.getVolume() / 10.0;
+                    var p = 100 * ((v - that.minVolume) / that.gapVolume);
+                    p = p < 0 ? 0 : p > 100 ? 100 : Math.round(p);
+                    debug("Got volume percent of " + p + "%");
+                    callback(false, p);
+                }, function(error) {
+                    callback(error, 0);
+                });
             })
-            .on('set', function(v, callback){
-			  var zone_name = 'Main_Zone';
-			  if(that.zone != 1) {
-				  zone_name = 'Zone_'+that.zone;
-			  }
-			  
-			  var mute_xml = '<YAMAHA_AV cmd="PUT"><'+zone_name+'><Volume><Mute>';
-              if(v) {
-                mute_xml += 'On';
-              } else {
-                mute_xml += 'Off';
-              }
-              mute_xml += '</Mute></Volume></'+zone_name+'></YAMAHA_AV>';
+            .on('set', function(p, callback) {
+                var v = ((p / 100) * that.gapVolume) + that.minVolume;
+                v = Math.round(v * 10.0);
+                debug("Setting volume to " + v);
+                yamaha.setVolumeTo(v, that.zone).then(function() {
+                    callback(false, p);
+                }, function(error) {
+                    callback(error, volCx.value);
+                });
+            })
+            .getValue(null, null); // force an asynchronous get
 
-              yamaha.SendXMLToReceiver(mute_xml).then(function(){
-                callback(false, v);
-              }, function(error){
-                callback(error, mutingCx.value);
-              });
+        var mutingCx = audioDeviceService.getCharacteristic(Characteristic.Mute);
+
+        mutingCx.on('get', function(callback, context) {
+                yamaha.getBasicInfo(that.zone).then(function(basicInfo) {
+                    callback(false, basicInfo.isMuted());
+                }, function(error) {
+                    callback(error, 0);
+                });
+            })
+            .on('set', function(v, callback) {
+                var zone_name = 'Main_Zone';
+                if (that.zone != 1) {
+                    zone_name = 'Zone_' + that.zone;
+                }
+
+                var mute_xml = '<YAMAHA_AV cmd="PUT"><' + zone_name + '><Volume><Mute>';
+                if (v) {
+                    mute_xml += 'On';
+                } else {
+                    mute_xml += 'Off';
+                }
+                mute_xml += '</Mute></Volume></' + zone_name + '></YAMAHA_AV>';
+
+                yamaha.SendXMLToReceiver(mute_xml).then(function() {
+                    callback(false, v);
+                }, function(error) {
+                    callback(error, mutingCx.value);
+                });
             })
             .getValue(null, null); // force an asynchronous get
 
@@ -318,27 +411,27 @@ YamahaAVRAccessory.prototype = {
 
         var inputCx = inputService.getCharacteristic(YamahaAVRPlatform.Input);
         inputCx.on('get', function(callback, context) {
-          yamaha.getBasicInfo().then(function(basicInfo){
-            callback(false, basicInfo.getCurrentInput());
-          }, function(error){
-            callback(error, 0);
-          });
-        })
-        .getValue(null, null); // force an asynchronous get
-        
-        if(this.showInputName == "yes") {
-          inputService.addCharacteristic(YamahaAVRPlatform.InputName);
-          var nameCx = inputService.getCharacteristic(YamahaAVRPlatform.InputName);
-          nameCx.on('get', function(callback, context) {
-            yamaha.getBasicInfo().then(function(basicInfo){
-              var name = basicInfo.YAMAHA_AV.Main_Zone[0].Basic_Status[0].Input[0].Input_Sel_Item_Info[0].Src_Name[0];
-              name = name.replace('Osdname:', '');
-              callback(false, name);
-            }, function(error){
-              callback(error, 0);
-            });
-          })
-          .getValue(null, null); // force an asynchronous get
+                yamaha.getBasicInfo().then(function(basicInfo) {
+                    callback(false, basicInfo.getCurrentInput());
+                }, function(error) {
+                    callback(error, 0);
+                });
+            })
+            .getValue(null, null); // force an asynchronous get
+
+        if (this.showInputName == "yes") {
+            inputService.addCharacteristic(YamahaAVRPlatform.InputName);
+            var nameCx = inputService.getCharacteristic(YamahaAVRPlatform.InputName);
+            nameCx.on('get', function(callback, context) {
+                    yamaha.getBasicInfo().then(function(basicInfo) {
+                        var name = basicInfo.YAMAHA_AV.Main_Zone[0].Basic_Status[0].Input[0].Input_Sel_Item_Info[0].Src_Name[0];
+                        name = name.replace('Osdname:', '');
+                        callback(false, name);
+                    }, function(error) {
+                        callback(error, 0);
+                    });
+                })
+                .getValue(null, null); // force an asynchronous get
         }
 
         return [informationService, switchService, audioDeviceService, inputService];

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ function YamahaSwitch(log, config, name, yamaha, sysConfig, preset) {
 
     this.nameSuffix = config["name_suffix"] || " Speakers";
     this.zone = config["zone"] || 1;
-    this.name = 'Radio ' + name.toString();
+    this.name = 'Preset ' + name.toString();
     this.serviceName = name + this.nameSuffix;
     this.setMainInputTo = config["setMainInputTo"];
     this.playVolume = this.config["play_volume"];

--- a/index.js
+++ b/index.js
@@ -233,16 +233,16 @@ YamahaSwitch.prototype = {
         switchService.getCharacteristic(Characteristic.On)
             .on('get', function(callback, context) {
                 yamaha.getBasicInfo().then(function(basicInfo) {
-                    this.log('Is On', basicInfo.isOn()); // True
-                    this.log('Input', basicInfo.getCurrentInput()); // Tuner
+                    debug('Is On', basicInfo.isOn()); // True
+                    debug('Input', basicInfo.getCurrentInput()); // Tuner
 
                     if (basicInfo.isOn() && basicInfo.getCurrentInput() == 'TUNER') {
 
                         yamaha.getTunerInfo().then(function(result) {
                             //console.log( 'TunerInfo', JSON.stringify(result,null, 0));
-                            this.log(result.Play_Info[0].Feature_Availability[0]); // Ready
-                            this.log(result.Play_Info[0].Search_Mode[0]); // Preset
-                            this.log(result.Play_Info[0].Preset[0].Preset_Sel[0]); // #
+                            debug(result.Play_Info[0].Feature_Availability[0]); // Ready
+                            debug(result.Play_Info[0].Search_Mode[0]); // Preset
+                            debug(result.Play_Info[0].Preset[0].Preset_Sel[0]); // #
                             if (result.Play_Info[0].Feature_Availability[0] == 'Ready' &&
                                 result.Play_Info[0].Search_Mode[0] == 'Preset' &&
                                 result.Play_Info[0].Preset[0].Preset_Sel[0] == this.preset) {
@@ -264,7 +264,7 @@ YamahaSwitch.prototype = {
             }.bind(this))
             .on('set', function(powerOn, callback) {
                 yamaha.selectTunerPreset(this.preset).then(function() {
-                    debug('Tuning radio to preset %s - %s', this.preset, this.name);
+                    this.log('Tuning radio to preset %s - %s', this.preset, this.name);
                     callback(null,1);
                 }.bind(this));
             }.bind(this));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "inherits": "^2.0.1",
     "request": "2.65.x",
-    "yamaha-nodejs": "0.4.x",
+    "yamaha-nodejs": "^0.7.7",
     "mdns": "^2.2.4",
     "q": "1.4.x",
     "debug": "^2.2.0",


### PR DESCRIPTION
I have added HomeKit switches for each radio preset.  I did this so I could say to Siri or Alexa,
Turn on radio 99.9

And the number would be the radio station for each preset.

For this to work, I also made changes to yamaha-nodejs and have submitted a pull request there as well.   Please don't merge until that is published as well.  And at the same time, you may want to update the version in the package.json dependancies.